### PR TITLE
Fix Offset Calculation in Tables with Complex Rowspans

### DIFF
--- a/lib/Tabletojson.ts
+++ b/lib/Tabletojson.ts
@@ -52,6 +52,8 @@ export type TableToJsonOptions = {
 
 export type CallbackFunction = (conversionResult: any) => any;
 
+type RowSpan = {content: string; value: number} | null;
+
 export class Tabletojson {
     static convert(
         html: string,
@@ -238,7 +240,7 @@ export class Tabletojson {
                 });
             });
 
-            let rowspans: any[] = [];
+            let rowspans: RowSpan[] = [];
 
             // Fetch each row
             $(table)
@@ -255,14 +257,14 @@ export class Tabletojson {
                     }
 
                     // Add content from rowspans
-                    rowspans.forEach((rowspan: any, index: number) => {
+                    rowspans.forEach((rowspan, index) => {
                         if (!rowspan) return;
 
                         setColumn(index, rowspan.content);
 
                         rowspan.value--;
                     });
-                    const nextrowspans: any[] = [...rowspans];
+                    const nextrowspans = [...rowspans];
 
                     const cells: cheerio.Cheerio = options.useFirstRowForHeadings
                         ? $(row).find('td, th')
@@ -278,7 +280,7 @@ export class Tabletojson {
                         }
 
                         // Apply rowspans offsets
-                        let aux: number = j;
+                        let aux = j;
                         j = 0;
                         do {
                             while (rowspans[j]) j++;
@@ -310,7 +312,7 @@ export class Tabletojson {
                     });
 
                     rowspans = nextrowspans;
-                    rowspans.forEach((rowspan: any, index: number) => {
+                    rowspans.forEach((rowspan, index) => {
                         if (rowspan && rowspan.value === 0) rowspans[index] = null;
                     });
 
@@ -403,4 +405,5 @@ export class Tabletojson {
         }
     }
 }
+
 export {Tabletojson as tabletojson};

--- a/test/tables.html
+++ b/test/tables.html
@@ -1390,6 +1390,53 @@
     </tbody>
 </table>
 
+<h2>Table #12-a: Table with extremely complex rowspans</h2>
+<table id="table12-a" class="table" border="1">
+    <thead>
+    <tr>
+        <th>Department</th>
+        <th>Major</th>
+        <th>Class</th>
+        <th>Instructor</th>
+        <th>Credit</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td rowspan="4">Engineering</td>
+            <td rowspan="3">Computer Science</td>
+            <td>CS101</td>
+            <td>Kim</td>
+            <td rowspan="2">3</td>
+        </tr>
+        <tr>
+            <td>CS201</td>
+            <td rowspan="2">Garcia</td>
+        </tr>
+        <tr>
+            <td>CS303</td>
+            <td>2</td>
+        </tr>
+        <tr>
+            <td>Electrical Engineering</td>
+            <td>EE101</td>
+            <td>Müller</td>
+            <td>3</td>
+        </tr>
+        <tr>
+            <td rowspan="2">Social Science</td>
+            <td rowspan="2">Economics</td>
+            <td>EC101</td>
+            <td>Nguyen</td>
+            <td rowspan="2">3</td>
+        </tr>
+        <tr>
+            <td>EC401</td>
+            <td>Smith</td>
+        </tr>
+    </tbody>
+</table>
+
 <h2>Table #13: Table with no headers</h2>
 <table id="table13" class="table" border="1">
     <tbody>

--- a/test/tabletojsonLocal.test.ts
+++ b/test/tabletojsonLocal.test.ts
@@ -618,7 +618,7 @@ describe('TableToJSON Local', function () {
         expect(table[4].Age).toBe('17');
     });
 
-    it.only('Complex rowspan usage leads to correct object representation', async function () {
+    it('Complex rowspan usage leads to correct object representation', async function () {
         const converted = tabletojson.convert(html, {
             id: ['table12-a'],
         });
@@ -627,8 +627,6 @@ describe('TableToJSON Local', function () {
         const table = converted[0];
 
         expect(table.length).toBe(6);
-
-        console.log(table);
 
         expect(table[0].Department).toBe('Engineering');
         expect(table[1].Department).toBe('Engineering');

--- a/test/tabletojsonLocal.test.ts
+++ b/test/tabletojsonLocal.test.ts
@@ -618,6 +618,54 @@ describe('TableToJSON Local', function () {
         expect(table[4].Age).toBe('17');
     });
 
+    it.only('Complex rowspan usage leads to correct object representation', async function () {
+        const converted = tabletojson.convert(html, {
+            id: ['table12-a'],
+        });
+        expect(converted).toBeDefined();
+        expect(converted.length).toBe(1);
+        const table = converted[0];
+
+        expect(table.length).toBe(6);
+
+        console.log(table);
+
+        expect(table[0].Department).toBe('Engineering');
+        expect(table[1].Department).toBe('Engineering');
+        expect(table[2].Department).toBe('Engineering');
+        expect(table[3].Department).toBe('Engineering');
+        expect(table[4].Department).toBe('Social Science');
+        expect(table[5].Department).toBe('Social Science');
+
+        expect(table[0].Major).toBe('Computer Science');
+        expect(table[1].Major).toBe('Computer Science');
+        expect(table[2].Major).toBe('Computer Science');
+        expect(table[3].Major).toBe('Electrical Engineering');
+        expect(table[4].Major).toBe('Economics');
+        expect(table[5].Major).toBe('Economics');
+
+        expect(table[0].Class).toBe('CS101');
+        expect(table[1].Class).toBe('CS201');
+        expect(table[2].Class).toBe('CS303');
+        expect(table[3].Class).toBe('EE101');
+        expect(table[4].Class).toBe('EC101');
+        expect(table[5].Class).toBe('EC401');
+
+        expect(table[0].Instructor).toBe('Kim');
+        expect(table[1].Instructor).toBe('Garcia');
+        expect(table[2].Instructor).toBe('Garcia');
+        expect(table[3].Instructor).toBe('Müller');
+        expect(table[4].Instructor).toBe('Nguyen');
+        expect(table[5].Instructor).toBe('Smith');
+
+        expect(table[0].Credit).toBe('3');
+        expect(table[1].Credit).toBe('3');
+        expect(table[2].Credit).toBe('2');
+        expect(table[3].Credit).toBe('3');
+        expect(table[4].Credit).toBe('3');
+        expect(table[5].Credit).toBe('3');
+    });
+
     it('Options: containsClasses', async function () {
         const converted = tabletojson.convert(html, {
             containsClasses: ['table'],


### PR DESCRIPTION
Hi! 

I've found an issue related to offset calculation in tables that utilize complex rowspans. The offset-adjusted index was consistently computed to be smaller by 1. This discrepancy led to a mismatch between cells and their corresponding columns. I added a test case that demonstrates the previously incorrect behavior. 

Besides, I slightly changed the type definitions related to offset calculation. I think its is better for type safety and developer guidance.